### PR TITLE
keep search state when toggle filtering

### DIFF
--- a/src/SearchPage/Facets.tsx
+++ b/src/SearchPage/Facets.tsx
@@ -9,6 +9,7 @@ import styled from "styled-components";
 import { colors, devices, Button } from "../ui";
 
 import { filteringContext } from "./Search";
+import { FilteringProps } from "./FilteringProps";
 
 export const Facets = () => {
   const { filtering, closeFiltering } = useContext(filteringContext);
@@ -95,8 +96,7 @@ const FacetContainer = styled.div`
   }
 `;
 
-type FacetsContainerProps = { filtering: boolean };
-const FacetsContainer = styled.div<FacetsContainerProps>`
+const FacetsContainer = styled.div<FilteringProps>`
   align-self: flex-start;
   min-width: 265px;
   background: ${colors.SecondaryBackground};

--- a/src/SearchPage/FilteringProps.ts
+++ b/src/SearchPage/FilteringProps.ts
@@ -1,0 +1,1 @@
+export type FilteringProps = { filtering: boolean };

--- a/src/SearchPage/Search.tsx
+++ b/src/SearchPage/Search.tsx
@@ -18,6 +18,7 @@ import config from "../config";
 import { Disclaimer } from "./Disclaimer";
 import { Facets } from "./Facets";
 import { ClinicalTrialHit } from "./ClinicalTrialHit";
+import { FilteringProps } from "./FilteringProps";
 
 const DEBOUNCE_SET_SEARCH_IN_MS = 1000;
 
@@ -102,25 +103,23 @@ export const SearchPage = () => {
         <Layout>
           <filteringContext.Provider value={{ filtering, closeFiltering }}>
             <Facets />
-            {!filtering && (
-              <SearchContainter>
-                <StyledSearchBox
-                  translations={{
-                    placeholder: "Search by keyword, drug, ..."
-                  }}
-                />
-                <StyledStats
-                  translations={{
-                    stats(nbHits, timeSpentMS) {
-                      return `${nbHits} trials found`;
-                    }
-                  }}
-                />
-                <StyledHits hitComponent={ClinicalTrialHit} />
-                <StyledPagination showFirst={false} padding={2} />
-                <Disclaimer />
-              </SearchContainter>
-            )}
+            <SearchContainter filtering={filtering}>
+              <StyledSearchBox
+                translations={{
+                  placeholder: "Search by keyword, drug, ..."
+                }}
+              />
+              <StyledStats
+                translations={{
+                  stats(nbHits, timeSpentMS) {
+                    return `${nbHits} trials found`;
+                  }
+                }}
+              />
+              <StyledHits hitComponent={ClinicalTrialHit} />
+              <StyledPagination showFirst={false} padding={2} />
+              <Disclaimer />
+            </SearchContainter>
           </filteringContext.Provider>
         </Layout>
         <FilterButton type="button" onClick={openFiltering}>
@@ -165,8 +164,9 @@ const Layout = styled.div`
   display: flex;
 `;
 
-const SearchContainter = styled.div`
+const SearchContainter = styled.div<FilteringProps>`
   width: 100%; /* for IE11 */
+  display: ${({ filtering }) => (filtering ? "none" : undefined)};
 `;
 
 const StyledHits = styled(Hits)`


### PR DESCRIPTION
Use css to hide the `SearchContainer` when filtering on mobile instead of removing it from the DOM, which was causing the search state to be erased.
Also scroll to the top when filtering to always see the top of the filter panel (as per: https://github.com/algolia/react-instantsearch/blob/218cbc61120abf162c3bb550bd1d13069370cc8e/examples/e-commerce/App.js#L86)

![Mar-24-2020 14-03-36](https://user-images.githubusercontent.com/30652355/77428893-1c660400-6dd9-11ea-8bc6-868d2cb194b0.gif)
