### PR TITLE
Display the laboratory icon on IE11 on small screens

### DIFF
--- a/src/pages/AnalysisPage/Introduction.tsx
+++ b/src/pages/AnalysisPage/Introduction.tsx
@@ -112,6 +112,7 @@ const Paragraph = styled.p`
 const IconContainer = styled.div`
   display: flex;
   align-self: center;
+  min-width: 250px; /* For IE11. Without it, the icon is not displayed on small screens */
   @media ${devices.Desktop} {
     align-self: flex-end;
     width: 100%;


### PR DESCRIPTION
This makes the laboratory icon displayed on small screens on IE11