### PR TITLE
Move build command in the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,6 +97,8 @@ jobs:
         run: cp src/config/config.prod.json src/config/config.json
       - run: yarn build
         name: Build the app
+      - run: yarn --cwd ./functions build
+        name: Build the functions
       - uses: w9jds/firebase-action@master
         name: Use firebase production environment
         if: github.ref == 'refs/heads/master'

--- a/firebase.json
+++ b/firebase.json
@@ -25,7 +25,7 @@
     ]
   },
   "functions": {
-    "predeploy": ["yarn --cwd \"$RESOURCE_DIR\" build"],
+    "predeploy": [],
     "source": "functions"
   },
   "firestore": {


### PR DESCRIPTION
The github action that launches firebase seems to use its own node version (12, when yarn requires 10)